### PR TITLE
提升 Gnome 桌面下跟随系统浅暗色主题的功能

### DIFF
--- a/test/theme-check.js
+++ b/test/theme-check.js
@@ -16,13 +16,22 @@ class CheckDark {
                 break;
             case "gnome":
             case "gnome-classic":
-                monitor = spawn("gsettings", [
-                    "monitor",
-                    "org.gnome.desktop.interface",
-                    "gtk-theme",
-                ]);
+                const gnomeVersion = execSync(`gnome-shell --version`).toString().replace(/[\r\n]/g, "").split(" ")
+                const gnomeVersionNum = gnomeVersion.length ? Number(gnomeVersion[2]) : 0
+                if (gnomeVersionNum >= 42) {
+                    monitor = spawn("gsettings", [
+                        "monitor",
+                        "org.gnome.desktop.interface",
+                        "color-scheme",
+                    ]);
+                } else {
+                    monitor = spawn("gsettings", [
+                        "monitor",
+                        "org.gnome.desktop.interface",
+                        "gtk-theme",
+                    ]);
+                }
                 break;
-
             default:
                 console.warn(
                     `NOT SUPPORTED !!! DESKTOP_SESSION: ${DESKTOP_SESSION}`
@@ -37,7 +46,7 @@ class CheckDark {
             monitor.stdout.on("data", (chunk) => {
                 // TODO: 防抖动包装
                 const data = chunk.toString();
-                const t = data.includes("dark");
+                const t = data.includes("dark") || data.includes("Dark");
                 console.log(data);
                 console.log("dark", t);
                 // (this._theme = t ? i.Dark : i.Light),
@@ -56,15 +65,24 @@ class CheckDark {
                 break;
             case "gnome":
             case "gnome-classic":
-                theme = execSync(
-                    `gsettings get org.gnome.desktop.interface gtk-theme`
-                );
+                // 判断 Gnome-Shell 版本
+                const gnomeVersion = execSync(`gnome-shell --version`).toString().replace(/[\r\n]/g, "").split(" ")
+                const gnomeVersionNum = gnomeVersion.length ? Number(gnomeVersion[2]) : 0
+                if (gnomeVersionNum >= 42) {
+                    theme = execSync(
+                        `gsettings get org.gnome.desktop.interface color-scheme`
+                    );
+                } else {
+                    theme = execSync(
+                        `gsettings get org.gnome.desktop.interface gtk-theme`
+                    );
+                }
                 break;
 
             default:
                 break;
         }
-        return theme.includes("dark");
+        return theme.includes("dark") || theme.includes("Dark");
     }
 }
 const cd = new CheckDark();
@@ -128,7 +146,7 @@ function original() {
                             "gtk-theme",
                         ]);
                         break;
-        
+
                     default:
                         console.warn(
                             `NOT SUPPORTED !!! DESKTOP_SESSION: ${DESKTOP_SESSION}`
@@ -147,7 +165,7 @@ function original() {
                         console.warn(data);
                         console.warn("dark", t);
                         (this._theme = t ? i.Dark : i.Light),
-                                this._onDidThemeChange.fire(this._theme);
+                            this._onDidThemeChange.fire(this._theme);
                     }, 400));
             }
             registerListeners() {
@@ -156,7 +174,7 @@ function original() {
                     (null === (e = this.mediaQuery) ||
                         void 0 === e ||
                         e.addEventListener("change", this.onMediaQueryChange),
-                    null === (t = this.mediaQuery2) ||
+                        null === (t = this.mediaQuery2) ||
                         void 0 === t ||
                         t.addEventListener("change", this.onMediaQueryChange));
             }
@@ -193,21 +211,21 @@ function original() {
             get mediaQuery() {
                 return (
                     this._mediaQuery ||
-                        (this._mediaQuery = window.matchMedia(
-                            "(prefers-color-scheme: dark)"
-                        )),
+                    (this._mediaQuery = window.matchMedia(
+                        "(prefers-color-scheme: dark)"
+                    )),
                     this._mediaQuery
                 );
             }
             get mediaQuery2() {
                 return (
                     void 0 === this._mediaQuery2 &&
-                        (global.contentWindow && global.contentWindow !== window
-                            ? (this._mediaQuery2 =
-                                  global.contentWindow.matchMedia(
-                                      "(prefers-color-scheme: dark)"
-                                  ))
-                            : (this._mediaQuery2 = null)),
+                    (global.contentWindow && global.contentWindow !== window
+                        ? (this._mediaQuery2 =
+                            global.contentWindow.matchMedia(
+                                "(prefers-color-scheme: dark)"
+                            ))
+                        : (this._mediaQuery2 = null)),
                     this._mediaQuery2
                 );
             }
@@ -227,7 +245,7 @@ function original() {
                             `gsettings get org.gnome.desktop.interface gtk-theme`
                         );
                         break;
-    
+
                     default:
                         break;
                 }

--- a/test/theme-check.js
+++ b/test/theme-check.js
@@ -17,7 +17,7 @@ class CheckDark {
             case "gnome":
             case "gnome-classic":
                 const gnomeVersion = execSync(`gnome-shell --version`).toString().replace(/[\r\n]/g, "").split(" ")
-                const gnomeVersionNum = gnomeVersion.length ? Number(gnomeVersion[2]) : 0
+                const gnomeVersionNum = gnomeVersion.length == 3 ? Number(gnomeVersion[2]) : 0
                 if (gnomeVersionNum >= 42) {
                     monitor = spawn("gsettings", [
                         "monitor",
@@ -67,7 +67,7 @@ class CheckDark {
             case "gnome-classic":
                 // 判断 Gnome-Shell 版本
                 const gnomeVersion = execSync(`gnome-shell --version`).toString().replace(/[\r\n]/g, "").split(" ")
-                const gnomeVersionNum = gnomeVersion.length ? Number(gnomeVersion[2]) : 0
+                const gnomeVersionNum = gnomeVersion.length == 3 ? Number(gnomeVersion[2]) : 0
                 if (gnomeVersionNum >= 42) {
                     theme = execSync(
                         `gsettings get org.gnome.desktop.interface color-scheme`


### PR DESCRIPTION
- 支持第三方GTK主题
- 支持 `Gnome42` 版本以上的全局亮暗色主题判断

ps: 写的不是特别好, 还望作者帮忙优化测试