### PR TITLE
Fixes #180 修复docker构建脚本错误

### DIFF
--- a/tools/build-with-docker.sh
+++ b/tools/build-with-docker.sh
@@ -14,6 +14,7 @@ docker run --rm -i \
     -e "ACTION_MODE=${ACTION_MODE:-false}" \
     -e "npm_config_prefix=/workspace/cache/npm/node_global" \
     -e "npm_config_cache=/workspace/cache/npm/node_cache" \
+    -e "CXXFLAGS=-std=c++17" \
     -w /workspace \
     -v "$root_dir:/workspace" \
     $image \


### PR DESCRIPTION
在原先的`docker run`命令中新加了一行`-e "CXXFLAGS=-std=c++17"`来指定编译器使用c++17标准进行编译。
Fixes #180